### PR TITLE
Added nil check to formatter output

### DIFF
--- a/Pod/Classes/JDFCurrencyTextField.m
+++ b/Pod/Classes/JDFCurrencyTextField.m
@@ -153,7 +153,7 @@
     if (number.doubleValue == 0) {
         number = [self.currencyFormatter numberFromString:currentString];
     }
-    if (currentString.length == 0) {
+    if (number == nil || currentString.length == 0) {
         number = @0;
     }
     


### PR DESCRIPTION
I am using ja_JP locale.

When I use "0" as input, text filed become empty.
When I use "", as input, text field become "¥0".
I believe both of them should return "¥0"

I also want to enhance invalid input handling such as "aaa"
It should return "¥0" as well.

To solve above problems. I have added nil check to formatter result.
