### PR TITLE
Remove grouping separator from decimal formatter

### DIFF
--- a/Pod/Classes/JDFCurrencyTextField.m
+++ b/Pod/Classes/JDFCurrencyTextField.m
@@ -85,6 +85,7 @@
         [_decimalFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
         [_decimalFormatter setLocale:self.locale];
     }
+    _decimalFormatter.usesGroupingSeparator = NO;
     return _decimalFormatter;
 }
 


### PR DESCRIPTION
Grouping separator makes it painful to modify number.

When user modify 1,000 to 1,0000, it become invalid and converted to 0.
But It is painful to keep proper grouping separator manually.
So I believe it is better to disable grouping separator when editing.
